### PR TITLE
Add basic raffle number reservation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Clone TabNews - Rifa Feature
+
+This project now includes a simple raffle number reservation feature.
+
+## Running
+
+```bash
+npm run dev
+```
+
+Then open [http://localhost:3000/rifas](http://localhost:3000/rifas) to select numbers.
+
+Numbers are persisted in PostgreSQL and, once selected, become unavailable for others.

--- a/infra/migrations/1754576664727_create-rifas-table.js
+++ b/infra/migrations/1754576664727_create-rifas-table.js
@@ -1,0 +1,18 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.createTable("rifas", {
+    numero: { type: "integer", primaryKey: true },
+    reservado: { type: "boolean", notNull: true, default: false },
+    reservado_por: { type: "text" },
+    data_reserva: { type: "timestamp" },
+  });
+
+  pgm.sql("INSERT INTO rifas (numero) SELECT generate_series(1,100);");
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable("rifas");
+};

--- a/pages/api/v1/rifas/[numero].js
+++ b/pages/api/v1/rifas/[numero].js
@@ -1,0 +1,46 @@
+import database from "infra/database.js";
+
+export default async function handler(request, response) {
+  if (request.method !== "POST") {
+    return response
+      .status(405)
+      .json({ error: `method "${request.method}" not allowed` });
+  }
+
+  const numero = parseInt(request.query.numero, 10);
+  const reservadoPor = request.body?.reservado_por || null;
+
+  let client;
+  try {
+    client = await database.getNewClient();
+    await client.query("BEGIN");
+    const selectResult = await client.query({
+      text: "SELECT numero FROM rifas WHERE numero = $1 AND reservado = false FOR UPDATE",
+      values: [numero],
+    });
+
+    if (selectResult.rowCount === 0) {
+      await client.query("ROLLBACK");
+      return response
+        .status(409)
+        .json({ error: "Número já reservado ou inexistente" });
+    }
+
+    await client.query({
+      text: "UPDATE rifas SET reservado = true, reservado_por = $1, data_reserva = NOW() WHERE numero = $2",
+      values: [reservadoPor, numero],
+    });
+    await client.query("COMMIT");
+    return response.status(200).json({ numero, reservado: true });
+  } catch (error) {
+    if (client) {
+      await client.query("ROLLBACK");
+    }
+    console.error(error);
+    return response.status(500).json({ error: "Falha ao reservar número" });
+  } finally {
+    if (client) {
+      await client.end();
+    }
+  }
+}

--- a/pages/api/v1/rifas/index.js
+++ b/pages/api/v1/rifas/index.js
@@ -1,0 +1,19 @@
+import database from "infra/database.js";
+
+export default async function handler(request, response) {
+  if (request.method !== "GET") {
+    return response
+      .status(405)
+      .json({ error: `method "${request.method}" not allowed` });
+  }
+
+  try {
+    const { rows } = await database.query(
+      "SELECT numero, reservado FROM rifas ORDER BY numero;",
+    );
+    return response.status(200).json(rows);
+  } catch (error) {
+    console.error(error);
+    return response.status(500).json({ error: "failed to list numbers" });
+  }
+}

--- a/pages/rifas/index.js
+++ b/pages/rifas/index.js
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+
+export default function RifaPage() {
+  const [numeros, setNumeros] = useState([]);
+
+  useEffect(() => {
+    fetch("/api/v1/rifas")
+      .then((res) => res.json())
+      .then(setNumeros);
+  }, []);
+
+  async function reservarNumero(numero) {
+    const response = await fetch(`/api/v1/rifas/${numero}`, {
+      method: "POST",
+    });
+    if (response.ok) {
+      setNumeros((nums) =>
+        nums.map((n) => (n.numero === numero ? { ...n, reservado: true } : n)),
+      );
+    } else {
+      alert("Número já reservado");
+    }
+  }
+
+  return (
+    <div>
+      <h1>Rifa</h1>
+      <ul
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          listStyle: "none",
+          padding: 0,
+        }}
+      >
+        {numeros.map((n) => (
+          <li key={n.numero} style={{ margin: "5px" }}>
+            <button
+              onClick={() => reservarNumero(n.numero)}
+              disabled={n.reservado}
+            >
+              {n.numero}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add database migration for raffle numbers
- implement API endpoints to list and reserve numbers
- create frontend page to pick raffle numbers

## Testing
- `npm test` *(fails: `docker` not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894b602c1ac8322afda09a5261137da